### PR TITLE
[Feature] LedgerState::get_ciphertexts method

### DIFF
--- a/storage/src/state/ledger.rs
+++ b/storage/src/state/ledger.rs
@@ -213,6 +213,10 @@ impl<N: Network, A: StorageAccess> LedgerState<N, A> {
         self.blocks.get_ciphertext(commitment)
     }
 
+    pub fn get_ciphertexts(&self) -> impl Iterator<Item = N::RecordCiphertext> + '_ {
+        self.blocks.get_ciphertexts()
+    }
+
     /// Returns the transition for a given transition ID.
     pub fn get_transition(&self, transition_id: &N::TransitionID) -> Result<Transition<N>> {
         self.blocks.get_transition(transition_id)
@@ -1309,6 +1313,10 @@ impl<N: Network, A: StorageAccess> BlockState<N, A> {
         self.transactions.get_ciphertext(commitment)
     }
 
+    pub fn get_ciphertexts(&self) -> impl Iterator<Item = N::RecordCiphertext> + '_ {
+        self.transactions.get_ciphertexts()
+    }
+
     /// Returns the transition for a given transition ID.
     fn get_transition(&self, transition_id: &N::TransitionID) -> Result<Transition<N>> {
         self.transactions.get_transition(transition_id)
@@ -1581,6 +1589,12 @@ impl<N: Network, A: StorageAccess> TransactionState<N, A> {
         }
 
         Err(anyhow!("Commitment {} is missing in storage", commitment))
+    }
+
+    pub fn get_ciphertexts(&self) -> impl Iterator<Item = N::RecordCiphertext> + '_ {
+        self.transitions
+            .values()
+            .flat_map(|(_, _, transition)| transition.ciphertexts().cloned().collect::<Vec<N::RecordCiphertext>>())
     }
 
     /// Returns the transition for a given transition ID.

--- a/storage/src/state/tests.rs
+++ b/storage/src/state/tests.rs
@@ -313,3 +313,20 @@ fn test_get_blocks_iterator() {
 
     assert_eq!(blocks_result, vec![Testnet2::genesis_block().clone(), blocks[0].clone()]);
 }
+
+#[test]
+fn test_get_all_ciphertexts() {
+    // Initialize a new ledger.
+    let ledger = create_new_ledger::<CurrentNetwork, RocksDB>();
+
+    let expected_ciphertexts: Vec<_> = ledger
+        .get_block(0)
+        .unwrap()
+        .commitments()
+        .map(|commitment| ledger.get_ciphertext(commitment).unwrap())
+        .collect();
+
+    let ciphertexts: Vec<_> = ledger.get_ciphertexts().collect();
+
+    assert_eq!(expected_ciphertexts, ciphertexts);
+}


### PR DESCRIPTION
## Motivation

This PR is related to #1725. It has some improvements in performance and now it returns all ciphertexts in the correct order.
The motivation is to get all the ciphertexts directly from LedgerState to avoid iterating over all the transactions and commitments to get them.

## Test Plan

There is a new test created in `storage/src/state/tests.rs`
- `test_get_all_ciphertexts` - This test asserts that this function gets all the ciphertexts in the ledger without a specific order.